### PR TITLE
Solved issue with CEC2013 example app causing trouble on Windows

### DIFF
--- a/libraryExamples/PaGMOEx/CMakeLists.txt
+++ b/libraryExamples/PaGMOEx/CMakeLists.txt
@@ -172,9 +172,12 @@ include(tudatLinkLibraries)
 ## Add Tudat pagmo examples
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/Problems")
 
-add_executable(application_PagmoCEC2013Comparison "${SRCROOT}/cec2013OptimizerComparison.cpp")
-setup_executable_target(application_PagmoCEC2013Comparison "${SRCROOT}")
-target_link_libraries(application_PagmoCEC2013Comparison pagmo pagmo2_library_example_problems tudat_input_output pthread ${Boost_LIBRARIES} )
+# Disable the CEC2013 example application on Windows as CEC2013 is not supported by MinGW
+if( NOT MINGW )
+    add_executable(application_PagmoCEC2013Comparison "${SRCROOT}/cec2013OptimizerComparison.cpp")
+    setup_executable_target(application_PagmoCEC2013Comparison "${SRCROOT}")
+    target_link_libraries(application_PagmoCEC2013Comparison pagmo pagmo2_library_example_problems tudat_input_output pthread ${Boost_LIBRARIES} )
+endif()
 
 add_executable(application_PagmoHimmelblauOptimization "${SRCROOT}/himmelblauOptimization.cpp")
 setup_executable_target(application_PagmoHimmelblauOptimization "${SRCROOT}")


### PR DESCRIPTION
Added CMake check to disable the CEC2013 example application on Windows, as the Pagmo source files contain large data arrays that MinGW supposedly cannot handle